### PR TITLE
Fix README path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Before you can run this project, you'll need the following:
 1.  **Clone the Repository:**
     ```bash
     git clone <repository-url>
-    cd chat-widget
+    cd venturajoyeria-chatbot
     ```
 
 2.  **Install Dependencies:**


### PR DESCRIPTION
## Summary
- update the repo path in the setup instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68546272fc048327bdef38dbca1c0e3d