### PR TITLE
Fix duplicate field in Shopify request

### DIFF
--- a/fetch-shopify.js
+++ b/fetch-shopify.js
@@ -15,7 +15,7 @@ export async function fetchProducts() {
   // 🔒 Add published_status=published to retrieve only live products
   let url = `https://${SHOP}/admin/api/2025-01/products.json` +
             `?limit=250&published_status=published` +
-            `&fields=id,title,body_html,variants,handle,images,variants`;
+            `&fields=id,title,body_html,variants,handle,images`;
 
   while (url) {
     const res = await fetch(url, {


### PR DESCRIPTION
## Summary
- request Shopify products without repeating the `variants` field

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685462586b388327b6fb8c08d7e3261d