### PR TITLE
Fix Pinecone configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Before you can run this project, you'll need the following:
     # Pinecone
     PINECONE_API_KEY="yourPineconeApiKey"
     PINECONE_ENVIRONMENT="yourPineconeEnvironment" # e.g., "gcp-starter" or "us-west1-gcp"
-    # Used to build the Pinecone controller URL
     PINECONE_INDEX="yourPineconeIndexName" # e.g., "chat-widget"
 
     # Shopify

--- a/pinecone.js
+++ b/pinecone.js
@@ -16,8 +16,8 @@ export function getPineconeIndex() {
   }
 
   const pinecone = new Pinecone({
-    apiKey:            PINECONE_API_KEY,
-    controllerHostUrl: `https://controller.${PINECONE_ENVIRONMENT}.pinecone.io`
+    apiKey:      PINECONE_API_KEY,
+    environment: PINECONE_ENVIRONMENT
   });
   return pinecone.Index(PINECONE_INDEX, "");
 }


### PR DESCRIPTION
## Summary
- use `environment` option when creating Pinecone client
- adjust README example to match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68557231b7fc8327b300407512921342